### PR TITLE
Fix tests, by using en0 instead of en9

### DIFF
--- a/Sources/NetworkExtensions/IP.swift
+++ b/Sources/NetworkExtensions/IP.swift
@@ -30,6 +30,7 @@ public enum IP: Codable, CustomStringConvertible, Equatable, Hashable { // swift
         case let .ipv4(v4):
             return v4.rawValue.map(String.init).joined(separator: ".")
         case let .ipv6(v6):
+
             let bigEndian: Bool = (1 == CFSwapInt32LittleToHost(1))
             var address = (0..<8)
                 .map { index in
@@ -40,9 +41,6 @@ public enum IP: Codable, CustomStringConvertible, Equatable, Hashable { // swift
             while (address.contains(":::")) {
                 address = address.replacingOccurrences(of: ":::", with: "::")
             }
-            dump(v6)
-            dump(v6.interface)
-            dump(v6.interface?.name)
             if let ifName = v6.interface?.name {
                 return "\(address)%\(ifName)"
             } else {

--- a/Sources/NetworkExtensions/IP.swift
+++ b/Sources/NetworkExtensions/IP.swift
@@ -30,7 +30,6 @@ public enum IP: Codable, CustomStringConvertible, Equatable, Hashable { // swift
         case let .ipv4(v4):
             return v4.rawValue.map(String.init).joined(separator: ".")
         case let .ipv6(v6):
-
             let bigEndian: Bool = (1 == CFSwapInt32LittleToHost(1))
             var address = (0..<8)
                 .map { index in
@@ -41,6 +40,9 @@ public enum IP: Codable, CustomStringConvertible, Equatable, Hashable { // swift
             while (address.contains(":::")) {
                 address = address.replacingOccurrences(of: ":::", with: "::")
             }
+            dump(v6)
+            dump(v6.interface)
+            dump(v6.interface?.name)
             if let ifName = v6.interface?.name {
                 return "\(address)%\(ifName)"
             } else {

--- a/Tests/NetworkExtensionsTests/NetworkExtensionsTests.swift
+++ b/Tests/NetworkExtensionsTests/NetworkExtensionsTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class NetworkExtensionsTests: XCTestCase {
     func testIPv6WithInterface() {
         // given
-        let input = "fe80::521e:2dff:fe3d:1d38%en9"
+        let input = "fe80::521e:2dff:fe3d:1d38%en0"
 
         // when
         guard let sut = IP(input),
@@ -15,8 +15,8 @@ final class NetworkExtensionsTests: XCTestCase {
 
         // then
         XCTAssertTrue(sut.isIPv6)
-        XCTAssertEqual(v6addr.interface?.name, "en9")
-        XCTAssertEqual(sut.ipString, "fe80::521e:2dff:fe3d:1d38%en9")
+        XCTAssertEqual(v6addr.interface?.name, "en0")
+        XCTAssertEqual(sut.ipString, "fe80::521e:2dff:fe3d:1d38%en0")
     }
 
     func testIpv4UrlString() {
@@ -36,7 +36,7 @@ final class NetworkExtensionsTests: XCTestCase {
 
     func testIpv6UrlString() {
         // given
-        let input = "fe80::521e:2dff:fe3d:1d38%en9"
+        let input = "fe80::521e:2dff:fe3d:1d38%en0"
 
         // when
         guard let sut = IP(input),
@@ -47,15 +47,15 @@ final class NetworkExtensionsTests: XCTestCase {
 
         // then
         XCTAssertTrue(sut.isIPv6)
-        XCTAssertEqual(sut.ipUrlString, "[fe80::521e:2dff:fe3d:1d38%en9]")
+        XCTAssertEqual(sut.ipUrlString, "[fe80::521e:2dff:fe3d:1d38%en0]")
     }
 
     func testPreferredAddress() {
         // given
-        let addresses = ["127.0.0.1", "fe80::521e:2dff:fe3d:1d38%en9", "2003:e1:d716:4d00:54f9:61b5:2507:11bd", "1.1.1.1"]
+        let addresses = ["127.0.0.1", "fe80::521e:2dff:fe3d:1d38%en0", "2003:e1:d716:4d00:54f9:61b5:2507:11bd", "1.1.1.1"]
             .compactMap { IP($0) }
 
         // then
-        XCTAssertEqual(addresses.preferredAddress?.ipString, "fe80::521e:2dff:fe3d:1d38%en9")
+        XCTAssertEqual(addresses.preferredAddress?.ipString, "fe80::521e:2dff:fe3d:1d38%en0")
     }
 }


### PR DESCRIPTION
In today's story, our hero finds out a very hidden side-effect, in the init of this innocent struct.