### PR TITLE
Bump FoundationExtensions to 0.1.19

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/teufelaudio/FoundationExtensions.git",
         "state": {
           "branch": null,
-          "revision": "79ebeb6b47b41f3423ac995638eba5788b373b5d",
-          "version": "0.1.17"
+          "revision": "def4b8d69600a909879cad4d851bc20b962440e7",
+          "version": "0.1.19"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .library(name: "NetworkExtensionsDynamic", targets: ["NetworkExtensions"])
     ],
     dependencies: [
-        .package(url: "https://github.com/teufelaudio/FoundationExtensions.git", .exact("0.1.17"))
+        .package(url: "https://github.com/teufelaudio/FoundationExtensions.git", .exact("0.1.19"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
New release, make sure FoundationExtensions version is the same for all consumers of FoundationExtension AND NetworkExtensions.