### PR TITLE
Avoid non empty promise

### DIFF
--- a/Sources/NetworkExtensions/Extensions/URLSessionProtocol.swift
+++ b/Sources/NetworkExtensions/Extensions/URLSessionProtocol.swift
@@ -8,6 +8,7 @@
 
 import Combine
 import Foundation
+import FoundationExtensions
 
 /// A protocol to abstract `URLSession`, it makes easier to mock requests and responses.
 public protocol URLSessionProtocol {
@@ -82,16 +83,16 @@ public final class URLSessionMock {
     public var dataTaskPassthrough = PassthroughSubject<(data: Data, response: URLResponse), URLError>()
 
     public lazy var dataTaskPromiseURL: (URL) -> Promise<(data: Data, response: URLResponse), URLError> = { url in
-        self.dataTaskPassthrough.assertNonEmptyPromise()
+        self.dataTaskPassthrough.promise(onEmpty: { .init(error: URLError(URLError.Code.cancelled)) })
     }
     public lazy var dataTaskPromiseURLRequest: (URLRequest) -> Promise<(data: Data, response: URLResponse), URLError> = { request in
-        self.dataTaskPassthrough.assertNonEmptyPromise()
+        self.dataTaskPassthrough.promise(onEmpty: { .init(error: URLError(URLError.Code.cancelled)) })
     }
     public lazy var resilientDataTaskPromiseURL: (URL) -> Promise<(data: Data, response: URLResponse), URLError> = { url in
-        self.dataTaskPassthrough.assertNonEmptyPromise()
+        self.dataTaskPassthrough.promise(onEmpty: { .init(error: URLError(URLError.Code.cancelled)) })
     }
     public lazy var resilientDataTaskPromiseURLRequest: (URLRequest) -> Promise<(data: Data, response: URLResponse), URLError> = { request in
-        self.dataTaskPassthrough.assertNonEmptyPromise()
+        self.dataTaskPassthrough.promise(onEmpty: { .init(error: URLError(URLError.Code.cancelled)) })
     }
     public func serverSendsDataSuccess(
         data: Data = Data(),

--- a/Sources/NetworkExtensions/REST/RESTClient.swift
+++ b/Sources/NetworkExtensions/REST/RESTClient.swift
@@ -8,6 +8,7 @@
 
 import Combine
 import Foundation
+import FoundationExtensions
 
 /// REST Client protocol, it's meant to be implemented to conform with specific REST servers.
 /// The implementations also should contain all possible actions in method extensions, so for example given


### PR DESCRIPTION
The NonEmptyPromise crashes tests with an assert that is hard to understand, especially in CI environments.
The intention is to make sure that an unused URLSessionMock is detected in a test run, but there are better
solutions for this.

With this change, the passthrough subject will emit a "canceled" error when the subscription ends and nothing
was sent through it. This behavior is not any closer to a real URL session, but it does allow the error to be
bubbled up to the consumer of the session, and the test will fail in a clear and understandable way.